### PR TITLE
Turned off Event.Mailer on Event Create

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -15,7 +15,7 @@ class EventsController < ApplicationController
     @event.friend = @friend
     @event.user = current_user
     if @event.save
-      EventMailer.notify14(@event).deliver_now
+      # EventMailer.notify14(@event).deliver_now
       redirect_to friend_events_path
     else
       render :new


### PR DESCRIPTION
Turned this off in the Event Controller for Event#Create:

`EventMailer.notify14(@event).deliver_now`

This is run by the `Event.Rake` which is scheduled in Heroku. Not required on Event Create.